### PR TITLE
chore: upgrade codecov-action to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       run: make test
     - name: Upload coverage
       if: matrix.django-version == 'pinned'
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false


### PR DESCRIPTION
**Description:**

Upgrade `codecov/codecov-action` in CI from `v5` to `v7` to avoid intermittent coverage upload failures seen with older versions of the action.

**Jira:**
[ENT-11952](https://2u-internal.atlassian.net/browse/ENT-11952)
**Changes**
- update `.github/workflows/ci.yml`
- change `codecov/codecov-action@v5` to `codecov/codecov-action@v7`