### PR TITLE
chore: pin `social-auth-*` packages that have working JWT auth

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -26,3 +26,8 @@ path<16.15.0
 # as the package is converted to an openedx plugin.
 # https://github.com/edx/braze-client/pull/30
 edx-braze-client<1
+
+# pinning social-auth-* packages to the latest working versions. Remove these pins
+# when this ticket gets resolved: https://2u-internal.atlassian.net/browse/ENT-12017
+social-auth-app-django>=5.9.0,<6.0.0
+social-auth-core>=4.9.1,<5.0.0


### PR DESCRIPTION
We don't yet know WHY JWT auth fails with newer package versions, but recent upgrades to these two packages are fully consistent with all the IDAs which have failing JWT
auth.

[ENT-12017](https://2u-internal.atlassian.net/browse/ENT-12017)