### PR TITLE
feat: add LicenseAction audit instrumentation for assign and revoke f…

### DIFF
--- a/license_manager/apps/api/tasks.py
+++ b/license_manager/apps/api/tasks.py
@@ -565,6 +565,8 @@ def revoke_all_licenses_task(
     actor_lms_user_id=None,
     actor_type=LicenseActorType.SYSTEM,
     correlation_id=None,
+    source=LicenseActionSource.CELERY_TASK,
+    **_ignored_kwargs,
 ):
     """
     Revokes all licenses associated with a subscription plan.
@@ -594,6 +596,7 @@ def revoke_all_licenses_task(
             **result,
             actor_lms_user_id=actor_lms_user_id,
             actor_type=actor_type,
+            source=source,
             correlation_id=correlation_id,
         )
 

--- a/license_manager/apps/api/tasks.py
+++ b/license_manager/apps/api/tasks.py
@@ -31,6 +31,9 @@ from license_manager.apps.subscriptions.constants import (
     REMINDER_EMAIL_BATCH_SIZE,
     REVOCABLE_LICENSE_STATUSES,
     TRACK_LICENSE_CHANGES_BATCH_SIZE,
+    LicenseActionSource,
+    LicenseActionType,
+    LicenseActorType,
     NotificationChoices,
 )
 from license_manager.apps.subscriptions.event_utils import (
@@ -40,6 +43,7 @@ from license_manager.apps.subscriptions.event_utils import (
 from license_manager.apps.subscriptions.models import (
     CustomerAgreement,
     License,
+    LicenseAction,
     Notification,
     SubscriptionPlan,
 )
@@ -398,7 +402,15 @@ def revoke_course_enrollments_for_user_task(user_id, enterprise_id):
         )
 
 
-def execute_post_revocation_tasks(revoked_license, original_status):
+def execute_post_revocation_tasks(
+    revoked_license,
+    original_status,
+    actor_lms_user_id=None,
+    actor_type=LicenseActorType.SYSTEM,
+    source=LicenseActionSource.CELERY_TASK,
+    correlation_id=None,
+    metadata=None,
+):
     """
     Executes a set of tasks after a license has been revoked.
 
@@ -406,6 +418,47 @@ def execute_post_revocation_tasks(revoked_license, original_status):
         - Revoke enrollments if the License has an original status of ACTIVATED.
         - Send email notification to ECS if the Subscription Plan has reached its revocation cap.
     """
+    action_metadata = {
+        'original_status': original_status,
+        **(metadata or {}),
+    }
+
+    # Guard against duplicate audit rows on async retries by reusing a deterministic idempotency key.
+    idempotency_key = action_metadata.get('idempotency_key')
+    if not idempotency_key and correlation_id:
+        idempotency_key = f'{correlation_id}:{revoked_license.uuid}:{LicenseActionType.REVOKED}'
+        action_metadata['idempotency_key'] = idempotency_key
+
+    try:
+        if idempotency_key and LicenseAction.objects.filter(
+            license=revoked_license,
+            action_type=LicenseActionType.REVOKED,
+            metadata__idempotency_key=idempotency_key,
+        ).exists():
+            logger.info(
+                'Skipping duplicate revoked LicenseAction for license %s with idempotency_key %s',
+                revoked_license.uuid,
+                idempotency_key,
+            )
+        else:
+            LicenseAction.objects.create(
+                license=revoked_license,
+                subscription_plan=revoked_license.subscription_plan,
+                enterprise_customer_uuid=revoked_license.subscription_plan.enterprise_customer_uuid,
+                action_type=LicenseActionType.REVOKED,
+                actor_type=actor_type,
+                actor_lms_user_id=actor_lms_user_id,
+                learner_lms_user_id=revoked_license.lms_user_id,
+                learner_email=revoked_license.user_email,
+                source=source,
+                correlation_id=correlation_id,
+                metadata=action_metadata,
+            )
+    except Exception:  # pylint: disable=broad-except
+        logger.exception(
+            'Failed to write revoked LicenseAction for license %s; continuing post-revocation tasks.',
+            revoked_license.uuid,
+        )
 
     # We should only need to revoke enrollments if the License has an original
     # status of ACTIVATED, pending users shouldn't have any enrollments.
@@ -507,7 +560,12 @@ def _aliased_recipient_object_from_email(user_email):
 
 
 @shared_task(base=LoggedTaskWithRetry)
-def revoke_all_licenses_task(subscription_uuid):
+def revoke_all_licenses_task(
+    subscription_uuid,
+    actor_lms_user_id=None,
+    actor_type=LicenseActorType.SYSTEM,
+    correlation_id=None,
+):
     """
     Revokes all licenses associated with a subscription plan.
 
@@ -532,7 +590,12 @@ def revoke_all_licenses_task(subscription_uuid):
                 raise
 
     for result in revocation_results:
-        execute_post_revocation_tasks(**result)
+        execute_post_revocation_tasks(
+            **result,
+            actor_lms_user_id=actor_lms_user_id,
+            actor_type=actor_type,
+            correlation_id=correlation_id,
+        )
 
 
 def _send_bulk_enrollment_results_email(

--- a/license_manager/apps/api/tests/test_tasks.py
+++ b/license_manager/apps/api/tests/test_tasks.py
@@ -695,6 +695,7 @@ class RevokeAllLicensesTaskTests(TestCase):
         for post_revoke_call in mock_execute_post_revocation_tasks.call_args_list:
             assert post_revoke_call.kwargs['actor_lms_user_id'] is None
             assert post_revoke_call.kwargs['actor_type'] == constants.LicenseActorType.SYSTEM
+            assert post_revoke_call.kwargs['source'] == constants.LicenseActionSource.CELERY_TASK
             assert post_revoke_call.kwargs['correlation_id'] is None
 
     @mock.patch('license_manager.apps.api.tasks.execute_post_revocation_tasks')
@@ -709,6 +710,7 @@ class RevokeAllLicensesTaskTests(TestCase):
             self.subscription_plan.uuid,
             actor_lms_user_id=42,
             actor_type=constants.LicenseActorType.ADMIN,
+            source=constants.LicenseActionSource.ADMIN_API_BULK,
             correlation_id=correlation_id,
         )
 
@@ -716,6 +718,7 @@ class RevokeAllLicensesTaskTests(TestCase):
         for post_revoke_call in mock_execute_post_revocation_tasks.call_args_list:
             assert post_revoke_call.kwargs['actor_lms_user_id'] == 42
             assert post_revoke_call.kwargs['actor_type'] == constants.LicenseActorType.ADMIN
+            assert post_revoke_call.kwargs['source'] == constants.LicenseActionSource.ADMIN_API_BULK
             assert post_revoke_call.kwargs['correlation_id'] == correlation_id
 
     @mock.patch('license_manager.apps.api.tasks.execute_post_revocation_tasks')

--- a/license_manager/apps/api/tests/test_tasks.py
+++ b/license_manager/apps/api/tests/test_tasks.py
@@ -33,6 +33,7 @@ from license_manager.apps.subscriptions.exceptions import LicenseRevocationError
 from license_manager.apps.subscriptions.models import (
     CustomerAgreement,
     License,
+    LicenseAction,
     Notification,
     SubscriptionPlan,
 )
@@ -691,6 +692,32 @@ class RevokeAllLicensesTaskTests(TestCase):
         mock_revoke_license.assert_has_calls(expected_calls, any_order=True)
         assert mock_execute_post_revocation_tasks.call_count == 2
 
+        for post_revoke_call in mock_execute_post_revocation_tasks.call_args_list:
+            assert post_revoke_call.kwargs['actor_lms_user_id'] is None
+            assert post_revoke_call.kwargs['actor_type'] == constants.LicenseActorType.SYSTEM
+            assert post_revoke_call.kwargs['correlation_id'] is None
+
+    @mock.patch('license_manager.apps.api.tasks.execute_post_revocation_tasks')
+    @mock.patch('license_manager.apps.subscriptions.api.revoke_license')
+    def test_revoke_all_licenses_task_with_actor_context(self, mock_revoke_license, mock_execute_post_revocation_tasks):
+        """
+        Verify revoke-all propagates actor/correlation context to post-revocation tasks.
+        """
+        correlation_id = 'corr-123'
+
+        tasks.revoke_all_licenses_task(
+            self.subscription_plan.uuid,
+            actor_lms_user_id=42,
+            actor_type=constants.LicenseActorType.ADMIN,
+            correlation_id=correlation_id,
+        )
+
+        assert mock_execute_post_revocation_tasks.call_count == 2
+        for post_revoke_call in mock_execute_post_revocation_tasks.call_args_list:
+            assert post_revoke_call.kwargs['actor_lms_user_id'] == 42
+            assert post_revoke_call.kwargs['actor_type'] == constants.LicenseActorType.ADMIN
+            assert post_revoke_call.kwargs['correlation_id'] == correlation_id
+
     @mock.patch('license_manager.apps.api.tasks.execute_post_revocation_tasks')
     @mock.patch('license_manager.apps.subscriptions.api.revoke_license')
     def test_revoke_all_licenses_task_error(self, mock_revoke_license, mock_execute_post_revocation_tasks):
@@ -751,6 +778,61 @@ class RevokeAllLicensesTaskTests(TestCase):
 
         self.assertEqual(mock_revoke_enrollments_delay.called, is_license_revoked)
         self.assertEqual(mock_cap_email_delay.called, revoke_limit_reached)
+
+        action = LicenseAction.objects.get(license=original_license)
+        assert action.action_type == constants.LicenseActionType.REVOKED
+        assert action.actor_type == constants.LicenseActorType.SYSTEM
+        assert action.source == constants.LicenseActionSource.CELERY_TASK
+        assert action.metadata['original_status'] == original_status
+
+    @mock.patch('license_manager.apps.api.tasks.revoke_course_enrollments_for_user_task.delay')
+    def test_execute_post_revocation_tasks_idempotent_for_same_correlation(
+        self,
+        mock_revoke_enrollments_delay,
+    ):
+        subscription_plan = SubscriptionPlanFactory.create()
+        original_license = LicenseFactory.create(
+            status=constants.ASSIGNED,
+            subscription_plan=subscription_plan,
+            lms_user_id=123,
+        )
+
+        revocation_result = revoke_license(original_license)
+        tasks.execute_post_revocation_tasks(**revocation_result, correlation_id='corr-123')
+        tasks.execute_post_revocation_tasks(**revocation_result, correlation_id='corr-123')
+
+        actions = LicenseAction.objects.filter(license=original_license)
+        assert actions.count() == 1
+        assert actions.first().metadata['idempotency_key'] == (
+            f'corr-123:{original_license.uuid}:{constants.LicenseActionType.REVOKED}'
+        )
+        mock_revoke_enrollments_delay.assert_not_called()
+
+    @mock.patch('license_manager.apps.api.tasks.logger.exception')
+    @mock.patch('license_manager.apps.api.tasks.LicenseAction.objects.create')
+    @mock.patch('license_manager.apps.api.tasks.revoke_course_enrollments_for_user_task.delay')
+    def test_execute_post_revocation_tasks_audit_failure_does_not_block_followup_tasks(
+        self,
+        mock_revoke_enrollments_delay,
+        mock_action_create,
+        mock_log_exception,
+    ):
+        subscription_plan = SubscriptionPlanFactory.create()
+        original_license = LicenseFactory.create(
+            status=constants.ACTIVATED,
+            subscription_plan=subscription_plan,
+            lms_user_id=123,
+        )
+        mock_action_create.side_effect = Exception('audit write failed')
+
+        revocation_result = revoke_license(original_license)
+        tasks.execute_post_revocation_tasks(**revocation_result, correlation_id='corr-456')
+
+        mock_revoke_enrollments_delay.assert_called_once_with(
+            user_id=123,
+            enterprise_id=str(subscription_plan.enterprise_customer_uuid),
+        )
+        mock_log_exception.assert_called_once()
 
 
 class EnterpriseEnrollmentLicenseSubsidyTaskTests(TestCase):

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -1774,6 +1774,7 @@ class LicenseViewSetActionTests(LicenseViewSetActionMixin, TestCase):
         for action in assign_actions:
             assert action.metadata['batch_size'] == 2
             assert action.metadata['requested_email_count'] == 2
+            assert action.learner_external_key is None
             assert action.metadata['learner_external_key'] is None
 
     @mock.patch('license_manager.apps.api.v1.views.logger.exception')
@@ -1859,6 +1860,14 @@ class LicenseViewSetActionTests(LicenseViewSetActionMixin, TestCase):
             else:
                 with self.assertRaises(ObjectDoesNotExist):
                     SubscriptionLicenseSource.objects.get(license=assigned_license)
+
+            assign_action = LicenseAction.objects.get(
+                license=assigned_license,
+                action_type=constants.LicenseActionType.ASSIGNED,
+            )
+            expected_external_key = salesforce_id.strip() if salesforce_id else None
+            assert assign_action.learner_external_key == expected_external_key
+            assert assign_action.metadata['learner_external_key'] == expected_external_key
 
     @ddt.data(True, False)
     def test_assign_with_less_salesforce_ids(self, use_superuser):
@@ -2752,6 +2761,7 @@ class LicenseViewSetRevokeActionTests(LicenseViewSetActionMixin, TestCase):
         assert call_args.args == (str(self.subscription_plan.uuid),)
         assert call_args.kwargs['actor_lms_user_id'] == self.super_user.id
         assert call_args.kwargs['actor_type'] == constants.LicenseActorType.ADMIN
+        assert call_args.kwargs['source'] == constants.LicenseActionSource.ADMIN_API_BULK
         assert call_args.kwargs['correlation_id']
 
     @ddt.data(

--- a/license_manager/apps/api/v1/tests/test_views.py
+++ b/license_manager/apps/api/v1/tests/test_views.py
@@ -46,6 +46,7 @@ from license_manager.apps.subscriptions.exceptions import LicenseRevocationError
 from license_manager.apps.subscriptions.models import (
     CustomerAgreement,
     License,
+    LicenseAction,
     SubscriptionLicenseSource,
     SubscriptionsFeatureRole,
     SubscriptionsRoleAssignment,
@@ -1762,6 +1763,46 @@ class LicenseViewSetActionTests(LicenseViewSetActionMixin, TestCase):
             self.subscription_plan.customer_agreement.enterprise_customer_uuid
         )
 
+        assign_actions = LicenseAction.objects.filter(
+            subscription_plan=self.subscription_plan,
+            action_type=constants.LicenseActionType.ASSIGNED,
+        )
+        assert assign_actions.count() == 2
+        assert set(assign_actions.values_list('source', flat=True)) == {constants.LicenseActionSource.ADMIN_API_BULK}
+        assert set(assign_actions.values_list('actor_type', flat=True)) == {constants.LicenseActorType.ADMIN}
+        assert len(set(assign_actions.values_list('correlation_id', flat=True))) == 1
+        for action in assign_actions:
+            assert action.metadata['batch_size'] == 2
+            assert action.metadata['requested_email_count'] == 2
+            assert action.metadata['learner_external_key'] is None
+
+    @mock.patch('license_manager.apps.api.v1.views.logger.exception')
+    @mock.patch('license_manager.apps.api.v1.views.LicenseAction.objects.bulk_create')
+    @mock.patch('license_manager.apps.api.v1.views.link_learners_to_enterprise_task.si')
+    @mock.patch('license_manager.apps.api.v1.views.send_assignment_email_task.si')
+    def test_assign_audit_failure_does_not_fail_assignment(
+        self,
+        mock_send_assignment_email_task,
+        mock_link_learners_task,
+        mock_bulk_create,
+        mock_log_exception,
+    ):
+        self._setup_request_jwt(user=self.user)
+        self._create_available_licenses()
+        mock_bulk_create.side_effect = Exception('audit write failed')
+
+        user_emails = ['bb8@mit.edu', self.test_email]
+        response = self.api_client.post(
+            self.assign_url,
+            {'greeting': self.greeting, 'closing': self.closing, 'user_emails': user_emails},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        self._assert_licenses_assigned(user_emails)
+        self.assertTrue(mock_send_assignment_email_task.called)
+        self.assertTrue(mock_link_learners_task.called)
+        mock_log_exception.assert_called_once()
+
     @mock.patch('license_manager.apps.api.v1.views.link_learners_to_enterprise_task.si')
     @mock.patch('license_manager.apps.api.v1.views.send_assignment_email_task.si')
     @mock.patch('license_manager.apps.api.utils.set_datadog_tags')
@@ -2373,10 +2414,12 @@ class LicenseViewSetRevokeActionTests(LicenseViewSetActionMixin, TestCase):
             mock.call(bob_license),
         ])
 
-        mock_execute_post_revocation_tasks.assert_has_calls([
-            mock.call(**revoke_alice_license_result),
-            mock.call(**revoke_bob_license_result),
-        ])
+        call_kwargs = [mock_call.kwargs for mock_call in mock_execute_post_revocation_tasks.call_args_list]
+        assert len(call_kwargs) == 2
+        assert {kwargs['source'] for kwargs in call_kwargs} == {constants.LicenseActionSource.ADMIN_API_BULK}
+        assert {kwargs['actor_type'] for kwargs in call_kwargs} == {constants.LicenseActorType.ADMIN}
+        assert {kwargs['actor_lms_user_id'] for kwargs in call_kwargs} == {self.user.id}
+        assert len({kwargs['correlation_id'] for kwargs in call_kwargs}) == 1
 
     @mock.patch('license_manager.apps.api.v1.views.execute_post_revocation_tasks')
     @mock.patch('license_manager.apps.api.v1.views.revoke_license')
@@ -2454,9 +2497,9 @@ class LicenseViewSetRevokeActionTests(LicenseViewSetActionMixin, TestCase):
             mock.call(alice_license_1),
         ])
 
-        mock_execute_post_revocation_tasks.assert_has_calls([
-            mock.call(**revoke_alice_license_result),
-        ])
+        mock_execute_post_revocation_tasks.assert_called_once()
+        actual_source = mock_execute_post_revocation_tasks.call_args.kwargs['source']
+        assert actual_source == constants.LicenseActionSource.ADMIN_API_BULK
 
     @ddt.data(
         ([{'name': 'user_email', 'filter_value': 'al'}], ['alice@example.com']),
@@ -2704,7 +2747,12 @@ class LicenseViewSetRevokeActionTests(LicenseViewSetActionMixin, TestCase):
         self._setup_request_jwt(user=self.super_user)
         response = self.api_client.post(self.revoke_all_licenses_url, {})
         assert response.status_code == status.HTTP_204_NO_CONTENT
-        mock_revoke_all_licenses_task.assert_called()
+        mock_revoke_all_licenses_task.assert_called_once()
+        call_args = mock_revoke_all_licenses_task.call_args
+        assert call_args.args == (str(self.subscription_plan.uuid),)
+        assert call_args.kwargs['actor_lms_user_id'] == self.super_user.id
+        assert call_args.kwargs['actor_type'] == constants.LicenseActorType.ADMIN
+        assert call_args.kwargs['correlation_id']
 
     @ddt.data(
         {'is_revocation_cap_enabled': True},

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -65,6 +65,7 @@ from license_manager.apps.subscriptions.exceptions import (
 from license_manager.apps.subscriptions.models import (
     CustomerAgreement,
     License,
+    LicenseAction,
     SubscriptionLicenseSource,
     SubscriptionLicenseSourceType,
     SubscriptionPlan,
@@ -1175,6 +1176,37 @@ class LicenseAdminViewSet(BaseLicenseViewSet):
                 logger.exception(error_message)
                 return Response(error_message, status=status.HTTP_422_UNPROCESSABLE_ENTITY)
             else:
+                correlation_id = str(uuid4())
+                actor_lms_user_id = request.user.id
+
+                try:
+                    LicenseAction.objects.bulk_create([
+                        LicenseAction(
+                            license=_license,
+                            subscription_plan=subscription_plan,
+                            enterprise_customer_uuid=subscription_plan.enterprise_customer_uuid,
+                            action_type=constants.LicenseActionType.ASSIGNED,
+                            actor_type=constants.LicenseActorType.ADMIN,
+                            actor_lms_user_id=actor_lms_user_id,
+                            learner_lms_user_id=_license.lms_user_id,
+                            learner_email=_license.user_email,
+                            source=constants.LicenseActionSource.ADMIN_API_BULK,
+                            correlation_id=correlation_id,
+                            metadata={
+                                'batch_size': len(assigned_licenses),
+                                'requested_email_count': len(user_emails),
+                                'learner_external_key': (
+                                    emails_and_sfids.get(_license.user_email) if emails_and_sfids else None
+                                ),
+                            },
+                        ) for _license in assigned_licenses
+                    ], batch_size=constants.LICENSE_BULK_OPERATION_BATCH_SIZE)
+                except Exception:  # pylint: disable=broad-except
+                    logger.exception(
+                        'Failed to write assigned LicenseAction rows for subscription %s; continuing assignment flow.',
+                        subscription_plan.uuid,
+                    )
+
                 # Track license changes and do any other tasks that may want to
                 # read from the License DB table outside of the transaction.atomic() block,
                 # so that they can read the committed and updated versions
@@ -1451,6 +1483,8 @@ class LicenseAdminViewSet(BaseLicenseViewSet):
 
         revocation_results = []
         error_messages = []
+        correlation_id = str(uuid4())
+        actor_lms_user_id = request.user.id
 
         with transaction.atomic():
             for user_email in user_emails:
@@ -1483,7 +1517,13 @@ class LicenseAdminViewSet(BaseLicenseViewSet):
         revocation_succeeded = []
         for revocation_result in revocation_results:
             user_email = revocation_result.pop('user_email', None)
-            execute_post_revocation_tasks(**revocation_result)
+            execute_post_revocation_tasks(
+                **revocation_result,
+                actor_lms_user_id=actor_lms_user_id,
+                actor_type=constants.LicenseActorType.ADMIN,
+                source=constants.LicenseActionSource.ADMIN_API_BULK,
+                correlation_id=correlation_id,
+            )
             revocation_succeeded.append({
                 'license_uuid': str(revocation_result['revoked_license'].uuid),
                 'original_status': str(revocation_result['original_status']),
@@ -1499,7 +1539,7 @@ class LicenseAdminViewSet(BaseLicenseViewSet):
             return Response(data=results, status=status.HTTP_207_MULTI_STATUS)
 
     @action(detail=False, methods=['post'], url_path='revoke-all')
-    def revoke_all(self, _, subscription_uuid=None):
+    def revoke_all(self, request, subscription_uuid=None):
         """
         Revokes all licenses in a subscription plan,
         This will result in any existing enrollments for the revoked users
@@ -1527,7 +1567,12 @@ class LicenseAdminViewSet(BaseLicenseViewSet):
             return Response('Cannot revoke all licenses when revocation cap is enabled for the subscription plan',
                             status=status.HTTP_422_UNPROCESSABLE_ENTITY)
 
-        revoke_all_licenses_task.delay(subscription_uuid)
+        revoke_all_licenses_task.delay(
+            subscription_uuid,
+            actor_lms_user_id=request.user.id,
+            actor_type=constants.LicenseActorType.ADMIN,
+            correlation_id=str(uuid4()),
+        )
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     @action(detail=False, methods=['get'])

--- a/license_manager/apps/api/v1/views.py
+++ b/license_manager/apps/api/v1/views.py
@@ -1190,13 +1190,16 @@ class LicenseAdminViewSet(BaseLicenseViewSet):
                             actor_lms_user_id=actor_lms_user_id,
                             learner_lms_user_id=_license.lms_user_id,
                             learner_email=_license.user_email,
+                            learner_external_key=(
+                                (emails_and_sfids.get(_license.user_email) or None) if emails_and_sfids else None
+                            ),
                             source=constants.LicenseActionSource.ADMIN_API_BULK,
                             correlation_id=correlation_id,
                             metadata={
                                 'batch_size': len(assigned_licenses),
                                 'requested_email_count': len(user_emails),
                                 'learner_external_key': (
-                                    emails_and_sfids.get(_license.user_email) if emails_and_sfids else None
+                                    (emails_and_sfids.get(_license.user_email) or None) if emails_and_sfids else None
                                 ),
                             },
                         ) for _license in assigned_licenses
@@ -1571,6 +1574,7 @@ class LicenseAdminViewSet(BaseLicenseViewSet):
             subscription_uuid,
             actor_lms_user_id=request.user.id,
             actor_type=constants.LicenseActorType.ADMIN,
+            source=constants.LicenseActionSource.ADMIN_API_BULK,
             correlation_id=str(uuid4()),
         )
         return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
### **PR Details**

https://2u-internal.atlassian.net/browse/ENT-12032

Implemented audit instrumentation for license assign, bulk revoke, and revoke-all flows using the new LicenseAction model.

### **Changes included:**

Added LicenseAction creation for successful license assignments with admin actor attribution, learner details, subscription plan, enterprise customer UUID, source, and correlation ID.

Added audit logging for bulk revoke operations with one LicenseAction per revoked license and a shared correlation ID across the bulk request.

Updated revoke-all flow to propagate actor_lms_user_id, actor_type, and correlation_id through the Celery task payload.

Implemented centralized revoke audit logging in execute_post_revocation_tasks() with retry-safe idempotency handling and preserved actor attribution for async workflows.

Added/updated tests covering assign, bulk revoke, revoke-all, async actor attribution, correlation ID propagation, and retry idempotency behavior.

### **Validation:**

 600 tests passed
 91% code coverage
 make style passed
 make quality passed

PR: https://github.com/edx/license-manager/compare/master...ENT-12032-audit-instrumentation-license-assign-revoke

This completes the audit instrumentation work required for ENT-12032 and aligns with the acceptance criteria for assign, bulk revoke, revoke-all, async actor attribution, and correlation ID propagation.
